### PR TITLE
adds options object for configuring ipHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,20 @@ module.exports = function generateCommonLog(request, response, options)
     var UA = request.headers['user-agent'] || '-';
     var referer = request.headers['referer'] || '-';
     var tstamp = response._time ? new Date(response._time) : new Date();
-    var remote = (options && options.ipHeader ? request.headers[options.ipHeader] : '') ||
-                 (request.socket ? request.socket.remoteAddress : '') || '';
     var accepts = request.headers['accept'] || '-';
     var elapsed = response._time ? (Date.now() - response._time) + ' ms' : '';
+
+    var remote = '';
+
+    if (options && options.ipHeader)
+    {
+        remote = request.headers[options.ipHeader];
+    }
+    else if (request.socket)
+    {
+        remote = request.socket.remoteAddress;
+    }
+
 
     var fields = [
         remote.replace('::ffff:', ''), // client ip

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 var strftime = require('prettydate').strftime;
 
-module.exports = function generateCommonLog(request, response)
+module.exports = function generateCommonLog(request, response, options)
 {
     var protocol = 'HTTP/' + request.httpVersion;
     var payload_len = response._data ? response._data.length : '-';
     var UA = request.headers['user-agent'] || '-';
     var referer = request.headers['referer'] || '-';
     var tstamp = response._time ? new Date(response._time) : new Date();
-    var remote = (request.socket ? request.socket.remoteAddress : '') || '';
+    var remote = (options && options.ipHeader ? request.headers[options.ipHeader] : '') ||
+                 (request.socket ? request.socket.remoteAddress : '') || '';
     var accepts = request.headers['accept'] || '-';
     var elapsed = response._time ? (Date.now() - response._time) + ' ms' : '';
 


### PR DESCRIPTION
This change allows us to do `var foo = generateCommonLog(request, response, {ipHeader: "fastly-client-ip"});`, so that we can specify exactly which IP we're getting.

Feedback 100% welcome!
